### PR TITLE
details one colunm styled-27

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8"/>
 		<meta name="viewport" content="width=device-width, initial-scale=1"/>
+		<link rel="stylesheet" href="/app.css">
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,6 +15,11 @@
 			object-fit: cover;
 		}
 
+    html {
+			background-color: #050542;
+      color: #66E5BF;
+		}
+
 		body {
 			/* colors */
 			--bg-dark: #050542;
@@ -32,6 +37,9 @@
 			--fs-answer: 2.25rem;
 			--fs-section: 3rem;
 			--fs-title: 3.375rem;
+
+      font-family: 'MontserratAlternates';
+      font-weight: var(--fw-reg);
 		}
 
 		@font-face {

--- a/src/routes/[id]/+layout.svelte
+++ b/src/routes/[id]/+layout.svelte
@@ -1,5 +1,8 @@
 <script>
 	import favicon from '$lib/assets/favicon.svg';
+    import { redirect, text } from '@sveltejs/kit';
+    import { nonpassive } from 'svelte/legacy';
+    import { normalizeModuleId } from 'vite/module-runner';
 
 	let { children } = $props();
 </script>
@@ -8,6 +11,75 @@
 	<link rel="icon" href={favicon} />
 
 	<style>
+		h1 {
+			justify-self: center;
+			font-size: var(--fs-title);
+			color: var(--text-color);
+		}
+
+		img {
+			border: 5px solid var(--text-color);
+			border-radius: 15px;
+		}
+
+		h2 {
+			font-size: var(--fs-section);
+		}
+
+		.basic-card {
+			border: 3px solid var(--text-color);
+			box-shadow: 7px 7px 0 var(--text-color);
+			border-radius: 15px;
+			margin: 1.5em 1em;
+			padding: 1em;
+		}
+
+		.section-bio h3 {
+			font-size: var(--fs-section);
+		}
+
+		.user-links {
+			display: grid;
+			grid-template-areas:
+			"title  title"
+			"git web";
+			height: 6em;
+		}
+
+		.user-links h3 {
+			grid-area: title;
+		}
+
+		.user-links a {
+			text-decoration: none;
+			color: var(--text-color);
+			padding: 0.5em;
+			border-radius: 15px;
+			width: min-content;
+			height: min-content;
+		}
+
+		.user-links a:hover {
+			background-color: var(--text-color);
+			color: var(--bg-dark);
+		}
+
+		.favo-card {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			list-style: none;
+		}
+
+		.favo-card h3 {
+			font-size: var(--fs-section);
+		}
+
+		.favo-card span {
+			font-size: var(--fs-answer);
+			color: var(--highlight-text);
+			font-weight: var(--fw-semib);
+		}
 	</style>
 </svelte:head>
 

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -8,15 +8,16 @@
 <h1>Squad 2F</h1>
 
 <img src="{member.avatar}" alt="avatar image van {member.name}" width="250" height="250">
+
 <h2>{member.name}</h2>
 
 <div class="info-container">
-    <article>
+    <article class="basic-card section-bio">
         <h3>Bio</h3>
         <p>{member.bio}</p>
     </article>
 
-    <article>
+    <article class="basic-card user-links">
         <h3>Links</h3>
         <a href="https://github.com/{member.github_handle}">Github</a>
         <a href="{member.website}">website</a>
@@ -25,7 +26,7 @@
 
 <ul class="Favo-slider">
     {#each filters as filter}
-    <li>
+    <li class="basic-card favo-card">
         <h3>{filter[1]}</h3>
         <span>{member[filter[0]]}</span>
     </li>


### PR DESCRIPTION
## Wat heb ik gemaakt/ Aangepast?

Resolves issue #27 
in deze issue heb ik alle elementen gestyled zonder de layout aan te passen.
hiervoor heb ik het figma design gevolgd

## Images/video
de details pagina ziet er nu zo uit:

[details-one-column.webm](https://github.com/user-attachments/assets/496c9c63-1baa-45fd-a313-3fcfef073ec1)

## Hoe het getest moet worden
Zouden jullie de branch kunnen openen en kijken of de code duidelijk geschreven is?
En wat vinden jullie van de styling?

de files waar ik CSS heb geschreven zijn:
- +src/routes/+layout.svelte (achtergrond kleur van de site)
- src/routes/[id]/+layout.svelte (styling voor de details pagina)

Als jullie tips hebben of fouten zien, hoor ik dat graag
@DivaniNL
@ColindeGroot 