### PR TITLE
bio afgekapt op 10 regels #27

### DIFF
--- a/src/routes/[id]/+layout.svelte
+++ b/src/routes/[id]/+layout.svelte
@@ -38,6 +38,13 @@
 			font-size: var(--fs-section);
 		}
 
+		.section-bio p {
+			display: -webkit-box;
+			-webkit-box-orient: vertical;
+			-webkit-line-clamp: 10;
+			overflow: hidden;
+		}
+
 		.user-links {
 			display: grid;
 			grid-template-areas:


### PR DESCRIPTION
wat heb ik veranderd?

de bio was lang, met [webkit line clamp](https://developer.mozilla.org/en-US/docs/Web/CSS/line-clamp#:~:text=%3C/p%3E-,CSS,-CSS) zorg ik nu ervoor dat  deze niet langer dan 10 regels kan zijn

<img width="300" height="500" alt="Screenshot 2025-09-04 194748" src="https://github.com/user-attachments/assets/e238ce25-ac84-4a14-b922-885893c40b18" />


