### PR TITLE
added breadcrumbs #59

### DIFF
--- a/src/routes/[id]/+layout.svelte
+++ b/src/routes/[id]/+layout.svelte
@@ -1,8 +1,5 @@
 <script>
 	import favicon from '$lib/assets/favicon.svg';
-    import { redirect, text } from '@sveltejs/kit';
-    import { nonpassive } from 'svelte/legacy';
-    import { normalizeModuleId } from 'vite/module-runner';
 
 	let { children } = $props();
 </script>
@@ -30,7 +27,7 @@
 		}
 
 		.basic-card {
-			border: 3px solid var(--text-color);
+			outline: 3px solid var(--text-color);
 			box-shadow: 7px 7px 0 var(--text-color);
 			border-radius: 15px;
 			margin: 1.5em calc(1em + 10px) 1.5em 1em;
@@ -119,6 +116,17 @@
 				}
 			}
 
+		}
+		.breadcrumbs {
+			grid-column: 1 / 1;	
+			grid-row: 2 / 2;
+			margin: 0.3em 0 0 1.5rem;
+		}
+		.breadcrumbs a{
+			color: white;
+		}
+		.breadcrumbs a[aria-current="true"]{
+			color: #fffc86
 		}
 
 	</style>

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -179,20 +179,23 @@
     console.log(DutchCountryName)
 </script>
 <div class="grid-wrapper">
-    <h1>Squad 2F</h1>
+    {#if member.name}
+        <h1>{member.name}</h1>
+    {/if}
+    <section class="breadcrumbs">
+        <p><a href="/" class="home-link" aria-current="false">Squad 2F</a> &gt; <a href="#" class="detail-link" aria-current="true">{member.name}</a></p>
+    </section>
     {#if member.mugshot}
           <img src="https://fdnd.directus.app/assets/{member.mugshot}?width=500&height=500" alt="foto van {member.name}" width=250 height=250/>
     {:else}
     <img src="https://avatars.githubusercontent.com/u/89637532?s=200&v=4" alt="MONKE" width=250 height=250/>
     
     {/if}
-    {#if member.name}
-        <h2>{member.name}</h2>
-    {/if}
+
     <div class="info-container">
         {#if member.bio}
             <article class="basic-card section-bio">
-                <h3>Bio</h3>
+                <h2>Bio</h2>
                 <p>{member.bio}</p>
             </article>
         {/if}


### PR DESCRIPTION
<img width="1472" height="598" alt="Scherm­afbeelding 2025-09-09 om 13 31 42" src="https://github.com/user-attachments/assets/8dad4f03-32f3-4ec5-a3c9-4686118d80e5" />


## Wat heb ik gedaan?

Ik heb breadcrumbs toegevoegd om de navigatie tussen beide pagina's te verbeteren.

Ook heb ik de actieve link gestyled met het aria-current attribuut. Op deze manier weten schermlezers ook wat de actieve link is.

Meer informatie over aria-current: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-current

@vsheo  Zou jij deze pull request willen controleren en mergen als je tevreden bent?